### PR TITLE
允许排除音声目录下的特定目录

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,6 +37,9 @@ const defaultConfig = {
     //   path: ''
     // }
   ],
+  excludeFolderGlobs: [
+    "**/@eaDir/**",
+  ],
   coverFolderDir: process.pkg ? path.join(process.execPath, '..', 'covers') : path.join(__dirname, 'covers'),
   databaseFolderDir: process.pkg ? path.join(process.execPath, '..', 'sqlite') : path.join(__dirname, 'sqlite'),
   lyricFolderDir: "", // lyric folder reuse databaseFolderDir relative path, for instance: ./sqlite/lyrics

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "limit-promise": "^1.0.6",
     "lodash": "^4.17.21",
     "md5": "^2.3.0",
+    "minimatch": "^3.0.4",
     "natural-orderby": "^2.0.3",
     "recursive-readdir": "^2.2.2",
     "socket.io": "^2.4.1",


### PR DESCRIPTION
群晖会生成 @eaDir 文件夹，目前的版本会把这些文件夹也显示在音声内容内。增加了一个配置项以根据 glob pattern 来排除文件。